### PR TITLE
reset hard before changing branches

### DIFF
--- a/cherry.js
+++ b/cherry.js
@@ -35,6 +35,8 @@ module.exports = class NextCherryPickPlugin {
         const branch = await getCurrentBranch();
         const commitToCherryPick = await auto.git.getSha();
 
+        // We don't care about the version that just published so get rid of it
+        await execPromise("git", ["reset", "--hard", "HEAD"]);
         // Switch to master
         await execPromise("git", ["checkout", auto.baseBranch]);
         // Cherry pick the commit


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.18-canary.14.105.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @autorelease/auto-single-package@0.0.18-canary.14.105.0
  # or 
  yarn add @autorelease/auto-single-package@0.0.18-canary.14.105.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.0.18-next.13`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - reset hard before changing branches [#14](https://github.com/hipstersmoothie/auto-single-package/pull/14) ([@hipstersmoothie](https://github.com/hipstersmoothie))
  - Test patch cherry-pick [#13](https://github.com/hipstersmoothie/auto-single-package/pull/13) ([@hipstersmoothie](https://github.com/hipstersmoothie))
  
  #### ⚠️ Pushed to `next`
  
  - add cherry pick plugin ([@hipstersmoothie](https://github.com/hipstersmoothie))
  - update auto ([@hipstersmoothie](https://github.com/hipstersmoothie))
  - new auto ([@hipstersmoothie](https://github.com/hipstersmoothie))
  - add file ([@hipstersmoothie](https://github.com/hipstersmoothie))
  - test next ([@hipstersmoothie](https://github.com/hipstersmoothie))
  
  #### Authors: 1
  
  - Andrew Lisowski ([@hipstersmoothie](https://github.com/hipstersmoothie))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
