### PR TITLE
fix cherry-pick command

### DIFF
--- a/cherry.js
+++ b/cherry.js
@@ -45,7 +45,12 @@ module.exports = class NextCherryPickPlugin {
         auto.logger.log.info("Switching to master...");
         await execPromise("git", ["checkout", auto.baseBranch]);
         auto.logger.log.info("Cherry picking the commit...");
-        await execPromise("git", ["cherry-pick", "-m", commitToCherryPick]);
+        await execPromise("git", [
+          "cherry-pick",
+          commitToCherryPick,
+          "-m",
+          1,
+        ]);
         auto.logger.log.info("Pushing the new commit...");
         await execPromise("git", ["push", auto.remote, auto.baseBranch]);
         auto.logger.log.info(`Switching back to "${branch}"...`);


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.20-canary.21.139.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @autorelease/auto-single-package@0.0.20-canary.21.139.0
  # or 
  yarn add @autorelease/auto-single-package@0.0.20-canary.21.139.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
